### PR TITLE
#25

### DIFF
--- a/Managed/UnrealEngine.Runtime/Directory.Build.props
+++ b/Managed/UnrealEngine.Runtime/Directory.Build.props
@@ -1,0 +1,23 @@
+<!--
+    MSBuild special user file which defines the props which should be used by any project. 
+    It is picked up by msbuild itself
+-->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Target Name="Copy OutPut to Binaries dir" AfterTargets="PostBuildEvent" 
+          Condition="'$(MSBuildProjectName)' != 'UnrealEngine.AssemblyRewriter'"
+    >
+    <PropertyGroup>
+        <SourcePath>$(MSBuildProjectDirectory)/$(OutDir)$(AssemblyName)</SourcePath>
+        <CopyPath>$(MSBuildStartupDirectory)/../../Binaries/Managed/$(AssemblyName)</CopyPath>
+    </PropertyGroup>
+    <Message Text="Copy output from '$(SourcePath)' to ' $(CopyPath))"/>
+    <Exec ConsoleToMSBuild="true"
+        Command="copy &quot;$(SourcePath).dll&quot; &quot;$(CopyPath).dll&quot; /y"
+        IgnoreExitCode ="false" 
+    />
+    <Exec ConsoleToMSBuild="true"
+        Command="copy &quot;$(SourcePath).pdb&quot; &quot;$(CopyPath).pdb&quot; /y"
+        IgnoreExitCode ="true"
+    />
+  </Target>  
+</Project>

--- a/Managed/UnrealEngine.Runtime/Loader/EntryPoint.cs
+++ b/Managed/UnrealEngine.Runtime/Loader/EntryPoint.cs
@@ -7,6 +7,7 @@ using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
 using System.Windows.Forms;
+using USharp;
 
 // NOTE: Do not change the name of this (entry point lookup is "UnrealEngine.EntryPoint.DllMain")
 namespace UnrealEngine
@@ -555,82 +556,6 @@ namespace UnrealEngine
                     }
                 }
             }
-        }
-    }
-
-    class Args
-    {
-        private Dictionary<string, string> args = new Dictionary<string, string>();
-
-        public Args(string arg)
-        {
-            if (arg != null)
-            {
-                string[] splitted = arg.Split(new char[] { '|' }, StringSplitOptions.RemoveEmptyEntries);
-                foreach (string str in splitted)
-                {
-                    int equalsIndex = str.IndexOf('=');
-                    if (equalsIndex > 0)
-                    {
-                        string key = str.Substring(0, equalsIndex).Trim();
-                        string value = str.Substring(equalsIndex + 1).Trim();
-                        if (!string.IsNullOrEmpty(key) && !string.IsNullOrEmpty(value))
-                        {
-                            args[key] = value;
-                        }
-                    }
-                }
-            }
-        }
-
-        public string this[string key]
-        {
-            get { return GetString(key); }
-        }
-
-        public bool Contains(string key)
-        {
-            return args.ContainsKey(key);
-        }
-
-        public string GetString(string key)
-        {
-            string value;
-            args.TryGetValue(key, out value);
-            return value;
-        }
-
-        public bool GetBool(string key)
-        {
-            string valueStr;
-            bool value;
-            if (args.TryGetValue(key, out valueStr) && bool.TryParse(valueStr, out value))
-            {
-                return value;
-            }
-            return false;
-        }
-
-        public int GetInt32(string key)
-        {
-            string valueStr;
-            int value;
-            if (args.TryGetValue(key, out valueStr) && int.TryParse(valueStr, out value))
-            {
-                return value;
-            }
-            return 0;
-        }
-
-        public long GetInt64(string key)
-        {
-            string valueStr;
-            long value;
-            if (args.TryGetValue(key, out valueStr) && long.TryParse(valueStr, out value))
-            {
-                return value;
-            }
-            return 0;
         }
     }
 

--- a/Managed/UnrealEngine.Runtime/Loader/Loader.csproj
+++ b/Managed/UnrealEngine.Runtime/Loader/Loader.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Loader</RootNamespace>
     <AssemblyName>Loader</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>
@@ -17,16 +17,15 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>..\..\..\Binaries\Managed\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
+    <OutputPath>bin\Debug\</OutputPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>..\..\..\Binaries\Managed\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -46,6 +45,12 @@
   <ItemGroup>
     <Compile Include="EntryPoint.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\USharp.Shared\USharp.Shared.csproj">
+      <Project>{728a3b8c-a410-4dec-8bc7-47d81da2b979}</Project>
+      <Name>USharp.Shared</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/Managed/UnrealEngine.Runtime/USharp.Editor/Project/EntryPoint.cs
+++ b/Managed/UnrealEngine.Runtime/USharp.Editor/Project/EntryPoint.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace UnrealEngine
+{
+    public class EntryPoint
+    {
+        public static int DllMain(string arg)
+        {
+            Debug.WriteLine("USharp: Editor functions boot up");
+            return 0;
+        }
+
+        public static byte[] Unload()
+        {
+            return new byte[0];
+        }
+    }
+}

--- a/Managed/UnrealEngine.Runtime/USharp.Editor/USharp.Editor.csproj
+++ b/Managed/UnrealEngine.Runtime/USharp.Editor/USharp.Editor.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netStandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\UnrealEngine.Runtime\UnrealEngine.Runtime.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Managed/UnrealEngine.Runtime/USharp.Shared/Args.cs
+++ b/Managed/UnrealEngine.Runtime/USharp.Shared/Args.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace USharp 
+{
+    public class Args
+    {
+        private Dictionary<string, string> args = new Dictionary<string, string>();
+
+        public Args(string arg)
+        {
+            if (arg != null)
+            {
+                string[] splitted = arg.Split(new char[] { '|' }, StringSplitOptions.RemoveEmptyEntries);
+                foreach (string str in splitted)
+                {
+                    int equalsIndex = str.IndexOf('=');
+                    if (equalsIndex > 0)
+                    {
+                        string key = str.Substring(0, equalsIndex).Trim();
+                        string value = str.Substring(equalsIndex + 1).Trim();
+                        if (!string.IsNullOrEmpty(key) && !string.IsNullOrEmpty(value))
+                        {
+                            args[key] = value;
+                        }
+                    }
+                }
+            }
+        }
+
+        public string this[string key]
+        {
+            get { return GetString(key); }
+        }
+
+        public bool Contains(string key)
+        {
+            return args.ContainsKey(key);
+        }
+
+        public string GetString(string key)
+        {
+            string value;
+            args.TryGetValue(key, out value);
+            return value;
+        }
+
+        public bool GetBool(string key)
+        {
+            string valueStr;
+            bool value;
+            if (args.TryGetValue(key, out valueStr) && bool.TryParse(valueStr, out value))
+            {
+                return value;
+            }
+            return false;
+        }
+
+        public int GetInt32(string key)
+        {
+            string valueStr;
+            int value;
+            if (args.TryGetValue(key, out valueStr) && int.TryParse(valueStr, out value))
+            {
+                return value;
+            }
+            return 0;
+        }
+
+        public long GetInt64(string key)
+        {
+            string valueStr;
+            long value;
+            if (args.TryGetValue(key, out valueStr) && long.TryParse(valueStr, out value))
+            {
+                return value;
+            }
+            return 0;
+        }
+    }
+}

--- a/Managed/UnrealEngine.Runtime/USharp.Shared/USharp.Shared.csproj
+++ b/Managed/UnrealEngine.Runtime/USharp.Shared/USharp.Shared.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+  </PropertyGroup>
+
+</Project>

--- a/Managed/UnrealEngine.Runtime/UnrealEngine.AssemblyRewriter/UnrealEngine.AssemblyRewriter.csproj
+++ b/Managed/UnrealEngine.Runtime/UnrealEngine.AssemblyRewriter/UnrealEngine.AssemblyRewriter.csproj
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>UnrealEngine.AssemblyRewriter</RootNamespace>
     <AssemblyName>UnrealEngine.AssemblyRewriter</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -80,6 +81,12 @@
       <Name>UnrealEngine.Runtime</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="NETStandard.Library" Version="2.0.1" />
+  </ItemGroup>  
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Managed/UnrealEngine.Runtime/UnrealEngine.AssemblyRewriter/app.config
+++ b/Managed/UnrealEngine.Runtime/UnrealEngine.AssemblyRewriter/app.config
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/></startup></configuration>

--- a/Managed/UnrealEngine.Runtime/UnrealEngine.Runtime.sln
+++ b/Managed/UnrealEngine.Runtime/UnrealEngine.Runtime.sln
@@ -12,7 +12,12 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{F98E80EC-0F91-42F0-9E1D-0FE57BDC924A}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
+		Directory.Build.props = Directory.Build.props
 	EndProjectSection
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "USharp.Editor", "USharp.Editor\USharp.Editor.csproj", "{92B3DB21-34C4-43CD-87A5-D62A0D13B1BE}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "USharp.Shared", "USharp.Shared\USharp.Shared.csproj", "{728A3B8C-A410-4DEC-8BC7-47D81DA2B979}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -31,6 +36,14 @@ Global
 		{C284889D-AA3A-4EC1-B4EA-FAA4A3A92C33}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{C284889D-AA3A-4EC1-B4EA-FAA4A3A92C33}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C284889D-AA3A-4EC1-B4EA-FAA4A3A92C33}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{92B3DB21-34C4-43CD-87A5-D62A0D13B1BE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{92B3DB21-34C4-43CD-87A5-D62A0D13B1BE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{92B3DB21-34C4-43CD-87A5-D62A0D13B1BE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{92B3DB21-34C4-43CD-87A5-D62A0D13B1BE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{728A3B8C-A410-4DEC-8BC7-47D81DA2B979}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{728A3B8C-A410-4DEC-8BC7-47D81DA2B979}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{728A3B8C-A410-4DEC-8BC7-47D81DA2B979}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{728A3B8C-A410-4DEC-8BC7-47D81DA2B979}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Managed/UnrealEngine.Runtime/UnrealEngine.Runtime/Internal/EntryPoint.cs
+++ b/Managed/UnrealEngine.Runtime/UnrealEngine.Runtime/Internal/EntryPoint.cs
@@ -6,6 +6,7 @@ using System.Runtime.InteropServices;
 using System.Text;
 using UnrealEngine.Runtime;
 using UnrealEngine.Runtime.Native;
+using USharp;
 
 namespace UnrealEngine
 {
@@ -94,82 +95,6 @@ namespace UnrealEngine
             TimeSpan endUnloadTime = DateTime.Now.TimeOfDay;
             FMessage.Log("EndUnload: " + endUnloadTime + " (" + (endUnloadTime - beginUnloadTime.TimeOfDay) + ")");
             return data;
-        }
-
-        class Args
-        {
-            private Dictionary<string, string> args = new Dictionary<string, string>();
-
-            public Args(string arg)
-            {
-                if (arg != null)
-                {
-                    string[] splitted = arg.Split(new char[] { '|' }, StringSplitOptions.RemoveEmptyEntries);
-                    foreach (string str in splitted)
-                    {
-                        int equalsIndex = str.IndexOf('=');
-                        if (equalsIndex > 0)
-                        {
-                            string key = str.Substring(0, equalsIndex).Trim();
-                            string value = str.Substring(equalsIndex + 1).Trim();
-                            if (!string.IsNullOrEmpty(key) && !string.IsNullOrEmpty(value))
-                            {
-                                args[key] = value;
-                            }
-                        }
-                    }
-                }
-            }
-
-            public string this[string key]
-            {
-                get { return GetString(key); }
-            }
-
-            public bool Contains(string key)
-            {
-                return args.ContainsKey(key);
-            }
-
-            public string GetString(string key)
-            {
-                string value;
-                args.TryGetValue(key, out value);
-                return value;
-            }
-
-            public bool GetBool(string key)
-            {
-                string valueStr;
-                bool value;
-                if (args.TryGetValue(key, out valueStr) && bool.TryParse(valueStr, out value))
-                {
-                    return value;
-                }
-                return false;
-            }
-
-            public int GetInt32(string key)
-            {
-                string valueStr;
-                int value;
-                if (args.TryGetValue(key, out valueStr) && int.TryParse(valueStr, out value))
-                {
-                    return value;
-                }
-                return 0;
-            }
-
-            public long GetInt64(string key)
-            {
-                string valueStr;
-                long value;
-                if (args.TryGetValue(key, out valueStr) && long.TryParse(valueStr, out value))
-                {
-                    return value;
-                }
-                return 0;
-            }
         }
     }
 }

--- a/Managed/UnrealEngine.Runtime/UnrealEngine.Runtime/Properties/AssemblyInfo.cs
+++ b/Managed/UnrealEngine.Runtime/UnrealEngine.Runtime/Properties/AssemblyInfo.cs
@@ -34,3 +34,4 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: InternalsVisibleTo("USharp.Editor")]

--- a/Managed/UnrealEngine.Runtime/UnrealEngine.Runtime/UnrealEngine.Runtime.csproj
+++ b/Managed/UnrealEngine.Runtime/UnrealEngine.Runtime/UnrealEngine.Runtime.csproj
@@ -9,25 +9,25 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>UnrealEngine.Runtime</RootNamespace>
     <AssemblyName>UnrealEngine.Runtime</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>..\..\..\Binaries\Managed\</OutputPath>
     <DefineConstants>TRACE;DEBUG;WITH_EDITORONLY_DATA</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DocumentationFile>
     </DocumentationFile>
+    <OutputPath>bin\Debug\</OutputPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>..\..\..\Binaries\Managed\</OutputPath>
     <DefineConstants>TRACE;WITH_EDITORONLY_DATA</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -394,7 +394,12 @@
   <ItemGroup>
     <Compile Include="Internal\CodeGenerator\CodeGenerator.Names.cs" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <ProjectReference Include="..\USharp.Shared\USharp.Shared.csproj">
+      <Project>{728a3b8c-a410-4dec-8bc7-47d81da2b979}</Project>
+      <Name>USharp.Shared</Name>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent>


### PR DESCRIPTION
-change target framework version to 4.7.2
-add editor only library
-add shared library for use by any project
-remove code duplication
-add automated copy step in UnrealEngine.Runtime.sln via Directory.Build.props -> this removes the need to specify the output directory manually. it also helps when the output path is extended by MSBUILD on its own (the case for netstandart libs)
-adding code to load editor library in editor